### PR TITLE
Enable Jenkins CI Documentation Generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,19 @@
+pipeline {
+  agent any
+  stages {
+    stage('Build') {
+      steps {
+        parallel(
+          "Build": {
+            sh './setup.sh'
+            sh 'cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang .'
+          },
+          "Documentation": {
+            sh 'doxygen ./doxygen-config'
+            sh 'zip -r docs.zip docs'
+          }
+        )
+      }
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,4 +16,9 @@ pipeline {
       }
     }
   }
+  post {
+    always {
+      archive 'docs.zip'
+    }
+  }
 }

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 
 # Download boost
 curl -L https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.gz --output boost.tar.gz
-tar -xvzf boost.tar.gz
+tar -xzf boost.tar.gz
 
 # Copy libraries
 mkdir include

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-
+if [ -d include/ ]; then
+  echo "include/ already exists"
+  exit 0
+fi
 # Download boost
 curl -L https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.gz --output boost.tar.gz
 tar -xzf boost.tar.gz


### PR DESCRIPTION
This commit enables Jenkins via ci.paradigmhyperloop.com

Jenkins with perform the following:

**Build**
- Run `./setup.sh`
- Run `cmake` in the root of the repo (not ./build) with a clang override

**Documentation**
- Run Doxygen
- Compress `./docs` into a zip file
- Archive the zip file in Jenkins.  You can access this file from the "Artifacts" tab on the Jenkins BlueOcean result

**Proof:**
https://ci.paradigmhyperloop.com/blue/organizations/jenkins/ParadigmHyperloop%2Fflight-computer/detail/jenkins/4/pipeline